### PR TITLE
Implemented Floyd-Steinberg-Dithering efficiently on-device

### DIFF
--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -53,7 +53,7 @@ const uint8_t GUI_ColorMap[GUI_COLORMAP_NUM_COLORS][3] = {
         {255, 127, 0}, // Orange
 };
 
-void GUI_AddClampedDelta(uint8_t* acc, int delta) {
+static void GUI_AddClampedDelta(uint8_t* acc, int delta) {
     int result = (int)*acc + delta;
     if (result < 0)
         *acc = 0;
@@ -121,17 +121,12 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     
     for(y = 0; y < bmpInfoHeader.biHeight; y++) {//Total display column
         for(x = 0; x < bmpInfoHeader.biWidth ; x++) {//Show a line in the line
-            if(f_read(&fil, (char *)Rdata, 1, &br) != FR_OK) {
+            if(f_read(&fil, Rdata, 3, &br) != FR_OK) {
                 perror("get bmpdata:\r\n");
-                break;
-            }
-            if(f_read(&fil, (char *)Rdata+1, 1, &br) != FR_OK) {
-                perror("get bmpdata:\r\n");
-                break;
-            }
-            if(f_read(&fil, (char *)Rdata+2, 1, &br) != FR_OK) {
-                perror("get bmpdata:\r\n");
-                break;
+                return 1;
+            } else if (br != 3) {
+                printf("early eof\r\n");
+                return 1;
             }
 
             // add original pixel data to dither line buffer in correct order

--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -64,8 +64,8 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     printf("open %s", path);
     fr = f_open(&fil, path, FA_READ);
     if (FR_OK != fr && FR_EXIST != fr) {
-        panic("f_open(%s) error: %s (%d)\n", path, FRESULT_str(fr), fr);
-        // exit(0);
+        printf("f_open(%s) error: %s (%d)\n", path, FRESULT_str(fr), fr);
+        return 1;
     }
     
     // Set the file pointer from the beginning
@@ -74,11 +74,13 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     if (br != sizeof(BMPFILEHEADER)) {
         printf("f_read bmpFileHeader error\r\n");
         // printf("br is %d\n", br);
+        return 1;
     }
     f_read(&fil, &bmpInfoHeader, sizeof(BMPINFOHEADER), &br);   // sizeof(BMPFILEHEADER) must be 50
     if (br != sizeof(BMPINFOHEADER)) {
         printf("f_read bmpInfoHeader error\r\n");
         // printf("br is %d\n", br);
+        return 1;
     }
     if(bmpInfoHeader.biWidth > bmpInfoHeader.biHeight)
         Paint_SetRotate(0);
@@ -91,6 +93,7 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     int readbyte = bmpInfoHeader.biBitCount;
     if(readbyte != 24){
         printf("Bmp image is not 24 bitmap!\n");
+        return 1;
     }
     // Read image data into the cache
     UWORD x, y;

--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -156,10 +156,10 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
             // perform dithering per color component channel
             for (int channel = 0; channel < 3; channel++) {
                 int error = (int)dither_lines[x + 1][0][channel] - (int)GUI_ColorMap[color_min_delta_idx][channel];
-                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][0][channel], (error * 7) >> 4);
-                GUI_AddClampedDelta(&dither_lines[x - 1 + 1][1][channel], (error * 3) >> 4);
-                GUI_AddClampedDelta(&dither_lines[x + 0 + 1][1][channel], (error * 5) >> 4);
-                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][1][channel], (error * 1) >> 4);
+                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][0][channel], (error * 7) / 16);
+                GUI_AddClampedDelta(&dither_lines[x - 1 + 1][1][channel], (error * 3) / 16);
+                GUI_AddClampedDelta(&dither_lines[x + 0 + 1][1][channel], (error * 5) / 16);
+                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][1][channel], (error * 1) / 16);
             }
 
             Paint_SetPixel(Xstart + bmpInfoHeader.biWidth-1-x, Ystart + y, color_min_delta_idx);


### PR DESCRIPTION
Converting and dithering images is a hassle and not trivial for many users (if you e.g. look at the Amazon reviews). I have thus implemented efficient dithering and color mapping in the firmware.

This lowers the requirements for images to only the following:
- 800x480 or 480x800
- 24bpp RGB888 bitmap

There is no perceivable increase in image update duration, hardly any more memory usage and the code is only run on image update every few minutes/hours, so the battery runtime should not be affected much.

Hope this helps! PS: I really hope a version with WiFi will be released eventually.