### PR TITLE
Improve bitmap compatibility and error handling

### DIFF
--- a/examples/EPD_7in3f_test.c
+++ b/examples/EPD_7in3f_test.c
@@ -61,15 +61,17 @@ int EPD_7in3f_display_BMP(const char *path, float vol)
     Paint_SelectImage(BlackImage);
     Paint_Clear(EPD_7IN3F_WHITE);
     
-    GUI_ReadBmp_RGB_7Color(path, 0, 0);
+    if (!GUI_ReadBmp_RGB_7Color(path, 0, 0)) {
+        Paint_DrawString_EN(10, 42, "Image cannot be displayed.", &Font16, EPD_7IN3F_BLACK, EPD_7IN3F_WHITE);
+        Paint_DrawString_EN(10, 58, path, &Font16, EPD_7IN3F_BLACK, EPD_7IN3F_WHITE);
+    }
 
-    if(Paint_GetRotate() == 90)
-        Paint_SetRotate(270);
-    else
-        Paint_SetRotate(180);
-    char strvol[21] = {0};
-    sprintf(strvol, "%f V", vol);
+    Paint_SetRotate((Paint_GetRotate() + 180) % 360);
+
     if(vol < 3.3) {
+        char strvol[21] = {0};
+        sprintf(strvol, "%f V", vol);
+
         Paint_DrawString_EN(10, 10, "Low voltage, please charge in time.", &Font16, EPD_7IN3F_BLACK, EPD_7IN3F_WHITE);
         Paint_DrawString_EN(10, 26, strvol, &Font16, EPD_7IN3F_BLACK, EPD_7IN3F_WHITE);
     }

--- a/examples/run_File.c
+++ b/examples/run_File.c
@@ -163,6 +163,18 @@ void ls(const char *dir) {
     f_closedir(&dj);
 }
 
+// adapted from https://stackoverflow.com/a/744822
+bool EndsWith(const char *str, const char *suffix)
+{
+    if (!str || !suffix)
+        return 0;
+    size_t lenstr = strlen(str);
+    size_t lensuffix = strlen(suffix);
+    if (lensuffix >  lenstr)
+        return 0;
+    return strncasecmp(str + lenstr - lensuffix, suffix, lensuffix) == 0;
+}
+
 /* 
     function: 
         Query the images in the directory and save their names to the appropriate file
@@ -218,7 +230,7 @@ void ls2file(const char *dir, const char *path) {
         }
         /* Create a string that includes the file name, the file size and the
          attributes string. */
-        if(fno.fname) {
+        if(!(fno.fattrib & AM_DIR) && fno.fname[0] != '.' && EndsWith(fno.fname, ".bmp")) {
             // f_printf(&fil, "%d %s\r\n", filNum, fno.fname);
             f_printf(&fil, "pic/%s\r\n", fno.fname);
             filNum++;

--- a/lib/Config/DEV_Config.h
+++ b/lib/Config/DEV_Config.h
@@ -62,6 +62,10 @@
 #define UWORD   uint16_t
 #define UDOUBLE uint32_t
 
+#define SBYTE  int8_t
+#define SWORD   int16_t
+#define SDOUBLE int32_t
+
 #define EPD_SPI_PORT 	spi1
 #define SD_SPI_PORT 	spi0
 #define RTC_I2C_PORT    i2c1

--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -53,7 +53,7 @@ const uint8_t GUI_ColorMap[GUI_COLORMAP_NUM_COLORS][3] = {
         {255, 127, 0}, // Orange
 };
 
-void GUI_AddClampedDelta(uint8_t* acc, int delta) {
+static void GUI_AddClampedDelta(uint8_t* acc, int delta) {
     int result = (int)*acc + delta;
     if (result < 0)
         *acc = 0;
@@ -121,17 +121,12 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     
     for(y = 0; y < bmpInfoHeader.biHeight; y++) {//Total display column
         for(x = 0; x < bmpInfoHeader.biWidth ; x++) {//Show a line in the line
-            if(f_read(&fil, (char *)Rdata, 1, &br) != FR_OK) {
+            if(f_read(&fil, Rdata, 3, &br) != FR_OK) {
                 perror("get bmpdata:\r\n");
-                break;
-            }
-            if(f_read(&fil, (char *)Rdata+1, 1, &br) != FR_OK) {
-                perror("get bmpdata:\r\n");
-                break;
-            }
-            if(f_read(&fil, (char *)Rdata+2, 1, &br) != FR_OK) {
-                perror("get bmpdata:\r\n");
-                break;
+                return 1;
+            } else if (br != 3) {
+                printf("early eof\r\n");
+                return 1;
             }
 
             // add original pixel data to dither line buffer in correct order

--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -64,8 +64,8 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     printf("open %s", path);
     fr = f_open(&fil, path, FA_READ);
     if (FR_OK != fr && FR_EXIST != fr) {
-        panic("f_open(%s) error: %s (%d)\n", path, FRESULT_str(fr), fr);
-        // exit(0);
+        printf("f_open(%s) error: %s (%d)\n", path, FRESULT_str(fr), fr);
+        return 1;
     }
     
     // Set the file pointer from the beginning
@@ -74,11 +74,13 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     if (br != sizeof(BMPFILEHEADER)) {
         printf("f_read bmpFileHeader error\r\n");
         // printf("br is %d\n", br);
+        return 1;
     }
     f_read(&fil, &bmpInfoHeader, sizeof(BMPINFOHEADER), &br);   // sizeof(BMPFILEHEADER) must be 50
     if (br != sizeof(BMPINFOHEADER)) {
         printf("f_read bmpInfoHeader error\r\n");
         // printf("br is %d\n", br);
+        return 1;
     }
     if(bmpInfoHeader.biWidth > bmpInfoHeader.biHeight)
         Paint_SetRotate(0);
@@ -91,6 +93,7 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     int readbyte = bmpInfoHeader.biBitCount;
     if(readbyte != 24){
         printf("Bmp image is not 24 bitmap!\n");
+        return 1;
     }
     // Read image data into the cache
     UWORD x, y;

--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -156,10 +156,10 @@ UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
             // perform dithering per color component channel
             for (int channel = 0; channel < 3; channel++) {
                 int error = (int)dither_lines[x + 1][0][channel] - (int)GUI_ColorMap[color_min_delta_idx][channel];
-                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][0][channel], (error * 7) >> 4);
-                GUI_AddClampedDelta(&dither_lines[x - 1 + 1][1][channel], (error * 3) >> 4);
-                GUI_AddClampedDelta(&dither_lines[x + 0 + 1][1][channel], (error * 5) >> 4);
-                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][1][channel], (error * 1) >> 4);
+                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][0][channel], (error * 7) / 16);
+                GUI_AddClampedDelta(&dither_lines[x - 1 + 1][1][channel], (error * 3) / 16);
+                GUI_AddClampedDelta(&dither_lines[x + 0 + 1][1][channel], (error * 5) / 16);
+                GUI_AddClampedDelta(&dither_lines[x + 1 + 1][1][channel], (error * 1) / 16);
             }
 
             Paint_SetPixel(Xstart + bmpInfoHeader.biWidth-1-x, Ystart + y, color_min_delta_idx);

--- a/lib/GUI/GUI_BMPfile.c
+++ b/lib/GUI/GUI_BMPfile.c
@@ -84,12 +84,14 @@ bool GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     if (br != sizeof(BMPFILEHEADER)) {
         printf("f_read bmpFileHeader error\r\n");
         // printf("br is %d\n", br);
+        f_close(&fil);
         return false;
     }
     f_read(&fil, &bmpInfoHeader, sizeof(BMPINFOHEADER), &br);   // sizeof(BMPFILEHEADER) must be 50
     if (br != sizeof(BMPINFOHEADER)) {
         printf("f_read bmpInfoHeader error\r\n");
         // printf("br is %d\n", br);
+        f_close(&fil);
         return false;
     }
 
@@ -105,10 +107,12 @@ bool GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
     // Determine if it is a monochrome or compressed bitmap
     if (bmpInfoHeader.biBitCount != 24) {
         printf("image is not 24bpp bitmap!\r\n");
+        f_close(&fil);
         return false;
     }
     if (bmpInfoHeader.biCompression != 0) {
         printf("image is compressed!\r\n");
+        f_close(&fil);
         return false;
     }
 
@@ -134,9 +138,11 @@ bool GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart)
         for(x = 0; x < bmpInfoHeader.biWidth ; x++) {//Show a line in the line
             if(f_read(&fil, Rdata, 3, &br) != FR_OK) {
                 perror("get bmpdata:\r\n");
+                f_close(&fil);
                 return false;
             } else if (br != 3) {
                 printf("early eof\r\n");
+                f_close(&fil);
                 return false;
             }
 

--- a/lib/GUI/GUI_BMPfile.h
+++ b/lib/GUI/GUI_BMPfile.h
@@ -48,7 +48,7 @@ typedef struct BMP_FILE_HEADER {
 typedef struct BMP_INFO {
     UDOUBLE biInfoSize;      //The size of the header
     UDOUBLE biWidth;         //The width of the image
-    UDOUBLE biHeight;        //The height of the image
+    SDOUBLE biHeight;        //The height of the image
     UWORD biPlanes;          //The number of planes in the image
     UWORD biBitCount;        //The number of bits per pixel
     UDOUBLE biCompression;   //Compression type
@@ -68,6 +68,6 @@ typedef struct RGB_QUAD {
 } __attribute__ ((packed)) BMPRGBQUAD;
 /**************************************** end ***********************************************/
 
-UBYTE GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart);
+bool GUI_ReadBmp_RGB_7Color(const char *path, UWORD Xstart, UWORD Ystart);
 
 #endif


### PR DESCRIPTION
This pull-request improves bitmap compatibility by supporting bitmaps that are encoded "upside-down" and correctly handles bitmap stride for bitmaps that are not sized to a byte-width that is a multiple of 4. It also performs more error checking on the image and displays a warning if an image is invalid and cannot be loaded.